### PR TITLE
Release/0.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 CC = clang
-CFLAGS = -Wall -Wextra -O2 -std=c99 -D_FORTIFY_SOURCE=2
+CFLAGS = -Wall -Wextra -pedantic -O2 -std=c99 -D_FORTIFY_SOURCE=2
 TARGET = fileclip
 .PHONY: all install uninstall clean test
 
-PREFIX = /usr/local/bin
+PREFIX ?= /usr/local/bin
 
 all: $(TARGET)
 
@@ -21,3 +21,6 @@ clean:
 
 test:
 	@echo "No tests defined. Add tests to validate the build."
+
+help:
+	@echo "Targets: all, install, uninstall, clean, test"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 CC = clang
-CFLAGS = -Wall -Wextra -O2
+CFLAGS = -Wall -Wextra -O2 -std=c99 -D_FORTIFY_SOURCE=2
 TARGET = fileclip
+.PHONY: all install uninstall clean test
+
+PREFIX = /usr/local/bin
 
 all: $(TARGET)
 
@@ -8,10 +11,13 @@ $(TARGET): fileclip.c
 	$(CC) $(CFLAGS) -o $(TARGET) fileclip.c
 
 install: $(TARGET)
-	install -m 0755 $(TARGET) /usr/local/bin/$(TARGET)
+	install -m 0755 $(TARGET) $(PREFIX)/$(TARGET)
 
 uninstall:
-	rm -f /usr/local/bin/$(TARGET)
+	rm -f $(PREFIX)/$(TARGET)
 
 clean:
 	rm -f $(TARGET)
+
+test:
+	@echo "No tests defined. Add tests to validate the build."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FileClip
 
-**fileclip** is a simple command-line clipboard tool for files and directories on macOS. It lets you "copy" a file or folder to the clipboard and "paste" it later into the current directory — like a CLI-based copy-paste for the file system.
+**fileclip** is a simple command-line clipboard tool for files and directories on macOS. It lets you "copy" a file or folder to the clipboard and "paste" or "move" it later into the current directory — like a CLI-based copy-paste for the file system.
 
 📋 Built on macOS clipboard utilities (`pbcopy` and `pbpaste`)  
 🧠 Remembers absolute file paths using your system clipboard  
@@ -12,6 +12,7 @@
 
 - Copy files or directories to clipboard (`-c`)
 - Paste to current working directory (`-p`)
+- Move to current working directory (`-m`)
 - Show current clipboard contents (`-d`)
 - Clear clipboard (`-r`)
 - Built specifically for macOS
@@ -40,6 +41,7 @@ fileclip -c somefile.txt      # Copy file
 fileclip -c somedir           # Copy folder
 fileclip -c                   # Copy current directory
 fileclip -p                   # Paste into current folder
+fileclip -m                   # Move into current folder
 fileclip -d                   # Show clipboard contents
 fileclip -r                   # Clear clipboard
 fileclip -v                   # Show version

--- a/README.md
+++ b/README.md
@@ -30,7 +30,16 @@ chmod +x ./install.sh
 ./install.sh
 ```
 
-This builds and installs the `fileclip` binary to `/usr/local/bin`.
+This builds and installs the `fileclip` binary to `/usr/local/bin` by default.
+
+#### **Custom Install Location**
+
+You can change the install location by overriding the `PREFIX` variable when running `make install`.  
+For example, to install to `/usr/bin`:
+
+```bash
+sudo make install PREFIX=/usr/bin
+```
 
 ---
 

--- a/fileclip.c
+++ b/fileclip.c
@@ -10,223 +10,229 @@
 
 void printHelp();
 void copy(const char *arg, const char *cwd);
-void paste();
+void paste(bool isMove);
 int isDir(const char *path);
 void showClipboardContents();
 void clearClipboard();
 
 /**
  * @brief Main entry point for the fileclip utility.
- * 
- * Handles command-line arguments and dispatches to the appropriate functionality.
- * 
+ *
+ * Handles command-line arguments and dispatches to the appropriate
+ * functionality.
+ *
  * @param argc Argument count
  * @param argv Argument vector
  * @return int Exit code
  */
 int main(int argc, char *argv[]) {
-  char cwd[PATH_MAX];
+    char cwd[PATH_MAX];
 
-  // Get current working directory
-  if (getcwd(cwd, sizeof(cwd)) == NULL) {
-    perror("fileclip: getcwd");
-    return 2;
-  }
-
-  // Check for valid argument count
-  if (argc < 2 || argc > 3) {
-    fprintf(stderr, "fileclip: invalid arguments\n");
-    printHelp();
-    return 1;
-  }
-
-  if (argc == 2) {
-    // Handle one-argument commands
-    if (strcmp(argv[1], "-c") == 0) {
-      copy("null", cwd); // Default to current directory
-    } else if (strcmp(argv[1], "-p") == 0) {
-      paste();
-    } else if (strcmp(argv[1], "-h") == 0) {
-      printHelp();
-    } else if (strcmp(argv[1], "-r") == 0) {
-      clearClipboard();
-      printf("fileclip: clipboard cleared\n");
-    } else if (strcmp(argv[1], "-d") == 0) {
-      showClipboardContents();
-    } else if (strcmp(argv[1], "-v") == 0 || strcmp(argv[1], "--version") == 0) {
-      printf("fileclip version %s\n", FILECLIP_VERSION);
-    } else {
-      fprintf(stderr, "fileclip: unknown argument\n");
-      return 1;
+    // Get current working directory
+    if (getcwd(cwd, sizeof(cwd)) == NULL) {
+        perror("fileclip: getcwd");
+        return 2;
     }
-  } else if (argc == 3) {
-    // Handle copy with file argument
-    if (strcmp(argv[1], "-c") == 0) {
-      copy(argv[2], cwd);
-    } else {
-      fprintf(stderr, "fileclip: invalid usage\n");
-      printHelp();
-      return 1;
-    }
-  }
 
-  return 0;
+    // Check for valid argument count
+    if (argc < 2 || argc > 3) {
+        fprintf(stderr, "fileclip: invalid arguments\n");
+        printHelp();
+        return 1;
+    }
+
+    if (argc == 2) {
+        // Handle one-argument commands
+        if (strcmp(argv[1], "-c") == 0) {
+            copy("null", cwd); // Default to current directory
+        } else if (strcmp(argv[1], "-p") == 0) {
+            paste(false); // Paste without moving
+        } else if (strcmp(argv[1], "-m") == 0) {
+            paste(true); // Paste and move
+        } else if (strcmp(argv[1], "-h") == 0) {
+            printHelp();
+        } else if (strcmp(argv[1], "-r") == 0) {
+            clearClipboard();
+            printf("fileclip: clipboard cleared\n");
+        } else if (strcmp(argv[1], "-d") == 0) {
+            showClipboardContents();
+        } else if (strcmp(argv[1], "-v") == 0 ||
+                   strcmp(argv[1], "--version") == 0) {
+            printf("fileclip version %s\n", FILECLIP_VERSION);
+        } else {
+            fprintf(stderr, "fileclip: unknown argument\n");
+            return 1;
+        }
+    } else if (argc == 3) {
+        // Handle copy with file argument
+        if (strcmp(argv[1], "-c") == 0) {
+            copy(argv[2], cwd);
+        } else {
+            fprintf(stderr, "fileclip: invalid usage\n");
+            printHelp();
+            return 1;
+        }
+    }
+    return 0;
 }
 
 /**
-  * @brief Prints usage information for the fileclip utility. 
+ * @brief Prints usage information for the fileclip utility.
  */
 void printHelp() {
-  printf("Usage: fileclip [-c] [-p] [-r] [-d] [-v] [file]\n");
-  printf("  -c [file]   Copy file or current directory to clipboard\n");
-  printf("  -p          Paste copied file or directory into current directory\n");
-  printf("  -d          Show clipboard contents\n");
-  printf("  -r          Clear clipboard\n");
-  printf("  -v          Show version\n");
-  printf("  -h          Show this help message\n");
+    printf("Usage: fileclip [-c] [-p] [-m] [-r] [-d] [-v] [file]\n");
+    printf("  -c [file]   Copy file or current directory to clipboard\n");
+    printf("  -p          Paste copied file or directory in current directory\n");
+    printf("  -m          Move copied file or directory in current directory\n");
+    printf("  -d          Show clipboard contents\n");
+    printf("  -r          Clear clipboard\n");
+    printf("  -v          Show version\n");
+    printf("  -h          Show this help message\n");
 }
 
 /**
  * @brief Copies a file or directory to the clipboard.
- * 
+ *
  * Uses `pbcopy` to store the absolute path of the file or directory.
- * 
+ *
  * @param arg File or directory to copy (or "null" for current directory)
  * @param cwd Current working directory
  */
 void copy(const char *arg, const char *cwd) {
-  char path[PATH_MAX];
-  char absPath[PATH_MAX];
+    char path[PATH_MAX];
+    char absPath[PATH_MAX];
 
-  // Determine the target path
-  if (strcmp(arg, "null") == 0) {
-    strcpy(path, cwd);
-  } else {
-    snprintf(path, sizeof(path), "%s/%s", cwd, arg);
-  }
+    // Determine the target path
+    if (strcmp(arg, "null") == 0) {
+        strcpy(path, cwd);
+    } else {
+        snprintf(path, sizeof(path), "%s/%s", cwd, arg);
+    }
 
-  // Check if file exists
-  if (access(path, F_OK) != 0) {
-    fprintf(stderr, "fileclip: file does not exist: %s\n", path);
-    exit(2);
-  }
+    // Check if file exists
+    if (access(path, F_OK) != 0) {
+        fprintf(stderr, "fileclip: file does not exist: %s\n", path);
+        exit(2);
+    }
 
-  // Resolve to absolute path
-  if (realpath(path, absPath) == NULL) {
-    perror("fileclip: realpath");
-    exit(2);
-  }
+    // Resolve to absolute path
+    if (realpath(path, absPath) == NULL) {
+        perror("fileclip: realpath");
+        exit(2);
+    }
 
-  // Copy path to clipboard
-  FILE *fp = popen("pbcopy", "w");
-  if (!fp) {
-    perror("fileclip: pbcopy");
-    exit(2);
-  }
+    // Copy path to clipboard
+    FILE *fp = popen("pbcopy", "w");
+    if (!fp) {
+        perror("fileclip: pbcopy");
+        exit(2);
+    }
 
-  fprintf(fp, "%s", absPath);
-  pclose(fp);
+    fprintf(fp, "%s", absPath);
+    pclose(fp);
 
-  printf("fileclip copied: %s\n", absPath);
+    printf("fileclip copied: %s\n", absPath);
 }
 
 /**
  * @brief Checks whether the given path is a directory.
- * 
+ *
  * @param path Path to check
  * @return int True if directory, false otherwise
  */
 int isDir(const char *path) {
-  struct stat statbuf;
-  return stat(path, &statbuf) == 0 && S_ISDIR(statbuf.st_mode);
+    struct stat statbuf;
+    return stat(path, &statbuf) == 0 && S_ISDIR(statbuf.st_mode);
 }
 
 /**
  * @brief Pastes the copied file or directory into the current directory.
- * 
+ *
  * Reads from the clipboard and uses `cp` to perform the paste.
+ *
+ * @param isMove If true, moves the file instead of copying it
  */
-void paste() {
-  char path[PATH_MAX];
+void paste(bool isMove) {
+    char path[PATH_MAX];
 
-  // Read path from clipboard
-  FILE *fp = popen("pbpaste", "r");
-  if (!fp) {
-    perror("fileclip: pbpaste");
-    exit(2);
-  }
+    // Read path from clipboard
+    FILE *fp = popen("pbpaste", "r");
+    if (!fp) {
+        perror("fileclip: pbpaste");
+        exit(2);
+    }
 
-  if (!fgets(path, PATH_MAX, fp)) {
-    fprintf(stderr, "fileclip: clipboard is empty or unreadable\n");
+    if (!fgets(path, PATH_MAX, fp)) {
+        fprintf(stderr, "fileclip: clipboard is empty or unreadable\n");
+        pclose(fp);
+        exit(1);
+    }
     pclose(fp);
-    exit(1);
-  }
-  pclose(fp);
 
-  // Remove trailing newline
-  path[strcspn(path, "\n")] = '\0';
+    // Remove trailing newline
+    path[strcspn(path, "\n")] = '\0';
 
-  // Check that the copied path still exists
-  if (access(path, F_OK) != 0) {
-    fprintf(stderr, "fileclip: copied path no longer exists: %s\n", path);
-    exit(2);
-  }
+    // Check that the copied path still exists
+    if (access(path, F_OK) != 0) {
+        fprintf(stderr, "fileclip: copied path no longer exists: %s\n", path);
+        exit(2);
+    }
 
-  // Prepare the appropriate cp command
-  bool dir = isDir(path);
-  char *cmd = malloc(PATH_MAX + 20); // Enough for "cp -R " + path + " ."
+    // Prepare the appropriate cp command
+    bool dir = isDir(path);
+    char *cmd = malloc(PATH_MAX + 20); // Enough for "cp -R " + path + " ."
 
-  if (!cmd) {
-    perror("fileclip: malloc");
-    exit(2);
-  }
+    if (!cmd) {
+        perror("fileclip: malloc");
+        exit(2);
+    }
 
-  snprintf(cmd, PATH_MAX + 20, "cp %s \"%s\" .", dir ? "-R" : "", path);
+    snprintf(cmd, PATH_MAX + 20, "cp %s \"%s\" .", dir ? "-R" : "", path);
 
-  int result = system(cmd);
-  free(cmd);
+    int result = system(cmd);
+    free(cmd);
 
-  if (result != 0) {
-    fprintf(stderr, "fileclip: paste failed\n");
-    exit(3);
-  }
+    if (result != 0) {
+        fprintf(stderr, "fileclip: paste failed\n");
+        exit(3);
+    }
 
-  printf("fileclip pasted: %s\n", path);
+    printf("fileclip pasted: %s\n", path);
 }
 
 /**
  * @brief Displays the current contents of the clipboard
  */
 void showClipboardContents() {
-  char path[PATH_MAX];
+    char path[PATH_MAX];
 
-  FILE *fp = popen("pbpaste", "r");
-  if (!fp) {
-    perror("fileclip: pbpaste");
-    exit(2);
-  }
+    FILE *fp = popen("pbpaste", "r");
+    if (!fp) {
+        perror("fileclip: pbpaste");
+        exit(2);
+    }
 
-  if (!fgets(path, PATH_MAX, fp)) {
-    fprintf(stderr, "fileclip: clipboard is empty\n");
+    if (!fgets(path, PATH_MAX, fp)) {
+        fprintf(stderr, "fileclip: clipboard is empty\n");
+        pclose(fp);
+        return;
+    }
     pclose(fp);
-    return;
-  }
-  pclose(fp);
 
-  // Remove newline character
-  path[strcspn(path, "\n")] = '\0';
-  printf("fileclip: %s\n", path);
+    // Remove newline character
+    path[strcspn(path, "\n")] = '\0';
+    printf("fileclip: %s\n", path);
 }
 
 /**
  * @brief Clears the clipboard contents.
- * 
+ *
  * Sends an empty string to `pbcopy`.
  */
 void clearClipboard() {
-  FILE *fp = popen("pbcopy", "w");
-  if (fp) {
-    fputs("", fp);
-    pclose(fp);
-  }
+    FILE *fp = popen("pbcopy", "w");
+    if (fp) {
+        fputs("", fp);
+        pclose(fp);
+    }
 }

--- a/fileclip.c
+++ b/fileclip.c
@@ -6,7 +6,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#define FILECLIP_VERSION "0.1.1"
+#define FILECLIP_VERSION "0.2.1"
 
 void printHelp(void);
 void copy(const char *arg, const char *cwd);

--- a/install.sh
+++ b/install.sh
@@ -8,5 +8,6 @@ sleep 1
 
 echo "Installing fileclip to /usr/local/bin..."
 sudo make install
+make clean
 
 echo "✅ Done. Run 'fileclip -h' for usage."


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `fileclip` project, including new functionality, improved code safety, and updated documentation. The most significant changes include adding a "move" feature, improving path validation, updating the `Makefile` for flexibility, and enhancing the documentation to reflect these updates.

### New Features and Functionality:
* Added a new `-m` flag to move files or directories from the clipboard to the current directory. This required updates to the `paste` function to support moving files, alongside copying. (`fileclip.c`: [[1]](diffhunk://#diff-bea880bb38e0cfeb70a0dc15c7428c7cfa3374b61c746edbd4bf89a491130378L48-R51) [[2]](diffhunk://#diff-bea880bb38e0cfeb70a0dc15c7428c7cfa3374b61c746edbd4bf89a491130378R168-R171) [[3]](diffhunk://#diff-bea880bb38e0cfeb70a0dc15c7428c7cfa3374b61c746edbd4bf89a491130378L177-R239)
* Updated the `printHelp` function and usage messages to include the new `-m` flag. (`fileclip.c`: [fileclip.cL59-R85](diffhunk://#diff-bea880bb38e0cfeb70a0dc15c7428c7cfa3374b61c746edbd4bf89a491130378L59-R85))

### Code Safety and Robustness:
* Improved path validation in the `copy` and `paste` functions to prevent unsafe characters (e.g., `..`, `&`, `;`) and ensure paths do not exceed `PATH_MAX`. (`fileclip.c`: [[1]](diffhunk://#diff-bea880bb38e0cfeb70a0dc15c7428c7cfa3374b61c746edbd4bf89a491130378L103-R126) [[2]](diffhunk://#diff-bea880bb38e0cfeb70a0dc15c7428c7cfa3374b61c746edbd4bf89a491130378R191-R196)
* Enhanced error handling by replacing `fprintf` with `fputs` for better readability and adding additional checks for invalid clipboard contents. (`fileclip.c`: [[1]](diffhunk://#diff-bea880bb38e0cfeb70a0dc15c7428c7cfa3374b61c746edbd4bf89a491130378L38-R39) [[2]](diffhunk://#diff-bea880bb38e0cfeb70a0dc15c7428c7cfa3374b61c746edbd4bf89a491130378L160-R182) [[3]](diffhunk://#diff-bea880bb38e0cfeb70a0dc15c7428c7cfa3374b61c746edbd4bf89a491130378L210-R249)

### Build System Improvements:
* Updated the `Makefile` to support a customizable `PREFIX` for installation and added `.PHONY` targets for better task management. (`Makefile`: [MakefileL2-R26](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L2-R26))

### Documentation Updates:
* Updated the `README.md` to document the new `-m` flag, clarify the default installation path, and explain how to specify a custom installation location using the `PREFIX` variable. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R42) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53)

### Miscellaneous:
* Incremented the version number from `0.1.1` to `0.2.1` to reflect the new features and improvements. (`fileclip.c`: [fileclip.cL9-R22](diffhunk://#diff-bea880bb38e0cfeb70a0dc15c7428c7cfa3374b61c746edbd4bf89a491130378L9-R22))
* Added a `make clean` step to the `install.sh` script to ensure a clean build. (`install.sh`: [install.shR11](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR11))